### PR TITLE
Python 3.11 Updates

### DIFF
--- a/tenyksservice/module_loader.py
+++ b/tenyksservice/module_loader.py
@@ -35,7 +35,7 @@ def make_module_from_file(module_name, module_filepath):
         file is created, and no entry is placed in `sys.modules`.
 
         """
-    py_source_open_mode = 'U'
+    py_source_open_mode = 'rt'
     py_source_description = (b".py", py_source_open_mode, imp.PY_SOURCE)
 
     with open(module_filepath, py_source_open_mode) as module_file:

--- a/tenyksservice/service.py
+++ b/tenyksservice/service.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import json
 import logging
 import re
@@ -149,7 +150,10 @@ class TenyksService:
 
         while True:
             self.logger.debug('running periodic task')
-            self.recurring()
+            if inspect.iscoroutinefunction(self.recurring):
+                await self.recurring()
+            else:
+                self.recurring()
             await asyncio.sleep(recurring_delay)
 
     async def _run_context_reaper(self):


### PR DESCRIPTION
* 'U' as an argument to `open()` was deprecated in 3.3 and removed in 3.9. See here: https://docs.python.org/3.9/whatsnew/3.9.html#changes-in-the-python-api
* Awaits the `recurring()` method on service workers if they're coroutines